### PR TITLE
return all prs in a list instead of grouping by repo

### DIFF
--- a/server/src/services/github.open.prs.ts
+++ b/server/src/services/github.open.prs.ts
@@ -4,7 +4,7 @@ import {
   GitHubServiceOptions,
   GitHubError
 } from "../types/github.types";
-import { FormattedPullRequest, RepoWithPRs } from "../types/formatted.types";
+import { FormattedPullRequest } from "../types/formatted.types";
 import { PullRequestDTO } from "../dtos/PullRequestDTO";
 import { fetchLastReviewOfPullRequest } from "./github.repos";
 
@@ -28,7 +28,7 @@ async function getAllPRsForUser(
   username: string,
   state: PRState = "open",
   options: GitHubServiceOptions = {}
-): Promise<RepoWithPRs[]> {
+): Promise<FormattedPullRequest[]> {
   try {
     const { perPage = 30, page = 1 } = options;
     const accountType = await getUserType(octokit, username);
@@ -71,18 +71,7 @@ async function getAllPRsForUser(
 
     const formatted: FormattedPullRequest[] = items.map((item: any) => PullRequestDTO.fromGitHubSearchAPIToModel(item));
 
-    const byRepo = new Map<string, FormattedPullRequest[]>();
-    for (const pr of formatted) {
-      if (!byRepo.has(pr.repo)) byRepo.set(pr.repo, []);
-      byRepo.get(pr.repo)!.push(pr);
-    }
-
-    const grouped: RepoWithPRs[] = Array.from(byRepo.entries()).map(([repo, pullRequests]) => ({
-      repo,
-      pullRequests
-    }));
-
-    return grouped;
+    return formatted;
   } catch (error: any) {
     const githubError: GitHubError = {
       message: error.message || `Error fetching ${state} pull requests for user ${username}`,

--- a/server/src/types/formatted.types.ts
+++ b/server/src/types/formatted.types.ts
@@ -60,11 +60,6 @@ export interface RepoWithReviewsAndErrors {
     failure_count: number;
 }
 
-export interface RepoWithPRs {
-    repo: string;
-    pullRequests: FormattedPullRequest[];
-}
-
 export interface FailedOperation {
     type: 'pull_request' | 'repository' | 'user';
     identifier: string;

--- a/server/src/types/github.types.ts
+++ b/server/src/types/github.types.ts
@@ -1,4 +1,4 @@
-import { FailedOperation, FormattedPullRequest, FormattedRepo, FormattedReview, RepoWithPRs, RepoWithReviewsAndErrors } from "./formatted.types";
+import { FailedOperation, FormattedPullRequest, FormattedRepo, FormattedReview, RepoWithReviewsAndErrors } from "./formatted.types";
 
 // GitHub API types
 
@@ -121,7 +121,7 @@ export interface GitHubReview {
 // Final Response Format
 export interface PullRequestResponseFormat {
     success: boolean;
-    data: RepoWithPRs[];
+    data: FormattedPullRequest[];
     pagination: Pagination;
     filters: Filters;
     sort: Sort

--- a/server/src/utils/pullRequestFormatter.ts
+++ b/server/src/utils/pullRequestFormatter.ts
@@ -1,4 +1,4 @@
-import { FormattedPullRequest, FormattedRepo, RepoWithPRs } from "../types/formatted.types";
+import { FormattedPullRequest, FormattedRepo } from "../types/formatted.types";
 import {
   PullRequestResponseFormat,
   PRState,
@@ -13,7 +13,7 @@ import {
  * Parameters for formatting pull request response
  */
 export interface FormatPullRequestResponseParams {
-  prs: RepoWithPRs[];
+  prs: FormattedPullRequest[];
   pageNum: number;
   perPage: number;
   prState: PRState;
@@ -33,7 +33,7 @@ export function formatPullRequestResponse(params: FormatPullRequestResponseParam
   // Calculate total PRs across all repositories
   const totalPRs = typeof totalPRsOverride === 'number'
     ? totalPRsOverride
-    : prs.reduce((sum, repo) => sum + repo.pullRequests.length, 0);
+    : prs.length
 
   // Calculate total pages based on total PRs and per_page
   const totalPages = Math.ceil(totalPRs / perPage);


### PR DESCRIPTION
For the endpoint `/api/prs/:username`, instead of returning the PRs grouped by repos, it returns all prs in a single array to get the PRs sorted by update date.